### PR TITLE
MANTA-5016 need node module for accessing manta storinfo service

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,33 +16,28 @@ markdown2extras: tables, code-friendly
 # Storinfo API
 
 
+## GetStorageNodes (GET /storagenodes)
 
-
-## GetSharks (GET /poll)
-
-Returns a list of storage nodes found in the `manta_storage` bucket, sorted by the ```manta_storage_id``` field.  Because the list of makos
+Returns a list of storage nodes found in the `manta_storage` bucket, sorted by the ```manta_storage_id``` field.  Because the list of storage nodes
 can be quite large, this endpoint enforces pagination to limit the response size.
 
-```poll``` will implement a cursor-based pagination scheme using the mako's ```manta_storage_id``` as the cursor value.
+```storagenodes``` will implement a cursor-based pagination scheme using the storage node's ```manta_storage_id``` as the cursor value.
 
 #### Inputs
 | Field        | Type    | Description                                      | Optional?
 | ------------ | ------- | ------------------------------------------------ |----------|
-| after_id     | String  | return results for mako with a storage id greater than "after_id" | Yes (default = "0") |
-| only_id     | String  | return result for only the mako specified by the storage id "only_id" | Yes |
+| after_id     | String  | return results for the storage node with a storage id greater than "after_id" | Yes (default = "0") |
 | limit        | Number  | max number of results to return | Yes (default/max = 500) |
 
 
-The response to ```/poll``` will include the following metadata:
+The response to ```/storagenodes``` will include the following metadata:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | last_id | String | The id of the last result returned |
 | next_link | String | URL to retrieve the next result set (using limit value from previous request) |
 
-A request where "after_id" is greater than all of the mako will result in an error (404).
-
-A request where "only_id" does not match any mako will result in an error (404).
+A request where "after_id" is greater than all of the storage nodes will result in an error (404).
 
 A request with an unsupported parameter or a bad parameter value will result in an error (400).
 
@@ -53,14 +48,20 @@ Requesting a limit that is greater than the number of available results will suc
 Get up to the first 100 results:
 
 ```
-/poll?limit=100
+/storagenodes?limit=100
 ```
 
 Get up to the next 100 results:
 
 ```
-/poll?limit=100&after_id=<last_id>
+/storagenodes?limit=100&after_id=<last_id>
 ```
+
+## GetStorageNode (GET /storagenodes/:storageid)
+
+Returns just the storage node with the `manta_storage_id` specified by "storageid", .
+
+A request where "storageid" does not match any storage nodes will result in an error (404).
 
 ## FlushCache (POST /flush)
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -80,16 +80,18 @@ function createServer(storinfo, log) {
 
     server.use(restify.plugins.queryParser());
 
-    server.get({ path: '/poll', name: 'GetSharks' }, poll);
+    server.get({ path: '/storagenodes', name: 'GetStorageNodes' },
+        getStorageNodes);
+    server.get({ path: '/storagenodes/:storageid', name: 'GetStorageNode' },
+        getStorageNode);
     server.post({ path: '/flush', name: 'FlushCache' }, flush);
 
     return server;
 }
 
-function poll(req, res, next) {
+function getStorageNodes(req, res, next) {
     var limit = req.storinfo.defPageSz;
     var after_id = null;
-    var only_id = null;
     var start_idx = 0;
     var end_idx;
     var idx;
@@ -113,12 +115,7 @@ function poll(req, res, next) {
                 }
                 break;
             case 'after_id':
-                /* XXX add code to sanity check id format */
                 after_id = req.params.after_id;
-                break;
-            case 'only_id':
-                /* XXX add code to sanity check id format */
-                only_id = req.params.only_id;
                 break;
             default:
                 err = new errors.BadRequestError({
@@ -126,23 +123,6 @@ function poll(req, res, next) {
                     }, 'Invalid parameter: ' + param);
                 return (next(err));
         }
-        if (after_id !== null && only_id !== null) {
-            err = new errors.BadRequestError({
-                statusCode: 400
-                }, 'after_id and only_id params are mutually exclusive');
-            return (next(err));
-        }
-    }
-
-    if (only_id !== null) {
-        /* JSSTYLED */
-        idx = sharkMap.findIndex(obj => obj.manta_storage_id === only_id);
-
-        if (idx === -1) {
-            return (next(new errors.NotFoundError()));
-        }
-        res.send(200, sharkMap[idx]);
-        return (next());
     }
 
     /*
@@ -224,6 +204,20 @@ function poll(req, res, next) {
      * Send out the result.
      */
     res.send(200, sharkMapSlice);
+    return (next());
+}
+
+function getStorageNode(req, res, next) {
+    var storageid = req.params.storageid;
+    var sharkMap = req.storinfo.operatorDcSharkMap;
+
+    /* JSSTYLED */
+    var idx = sharkMap.findIndex(obj => obj.manta_storage_id === storageid);
+
+    if (idx === -1) {
+        return (next(new errors.NotFoundError()));
+    }
+    res.send(200, sharkMap[idx]);
     return (next());
 }
 


### PR DESCRIPTION
Based on Trent's feedback for the MANTA-5016 changes in the node-storinfo repo, this commit reworks the Storinfo API, as follows:

1) Rename GetSharks method to GetStorageNodes
2) Change  route from /poll to /storagenodes
3) remove "only_id" param from /storagenodes
4) Implement new GetStorageNode (singular) method that allows retrieving single storage node record using manta storage id.  New method has route: /storagenodes/:storageid
