### PR TITLE
TOOLS-2582 Slack channels need renaming or not specifying in Jenkinsfiles, post-EdgeCast-move.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2021 Joyent, Inc.
+ * Copyright 2025 MNX Cloud, Inc.
  */
 
 @Library('jenkins-joylib@v1.0.8') _
@@ -54,8 +55,8 @@ pipeline {
 
     post {
         always {
-            joySlackNotifications(channel: 'jenkins')
-            joySlackNotifications(channel: 'rebalancer')
+            joySlackNotifications()
+            /* joySlackNotifications(channel: 'rebalancer') */
         }
     }
 }


### PR DESCRIPTION
I'm hoping I can comment-out the one line in case in some future we want a "rebalancer" channel back?